### PR TITLE
Make OPTIM copy loop faster and smaller.

### DIFF
--- a/6502/zx02-optim.asm
+++ b/6502/zx02-optim.asm
@@ -2,7 +2,7 @@
 ; ----------------------------
 ;
 ; Decompress ZX02 data (6502 optimized format), optimized for speed and size
-;  138 bytes code, 57.6 cycles/byte in test file.
+;  137 bytes code, TODO cycles/byte in test file.
 ;
 ; Compress with:
 ;    zx02 input.bin output.zx0
@@ -60,7 +60,7 @@ cop0          lda   (ZX0_src), y
               inx
               jsr   get_elias
 dzx0s_copy
-              lda   ZX0_dst
+              tya
               sbc   offset  ; C=0 from get_elias
               sta   pntr
               lda   ZX0_dst+1
@@ -68,14 +68,14 @@ dzx0s_copy
               sta   pntr+1
 
 cop1
+              ldy   ZX0_dst
               lda   (pntr), y
-              inc   pntr
-              bne   @+
-              inc   pntr+1
+              ldy   #0
 @             sta   (ZX0_dst),y
               inc   ZX0_dst
               bne   @+
               inc   ZX0_dst+1
+              inc   pntr+1
 @             dex
               bne   cop1
 

--- a/6502/zx102-optim.asm
+++ b/6502/zx102-optim.asm
@@ -2,7 +2,7 @@
 ; ---------------------------------
 ;
 ; Decompress ZX02 data in ZX1 mode (6502 optimized format), optimized for speed
-; and size 144 bytes code, 56.0 cycles/byte in test file.
+; and size 143 bytes code, TODO cycles/byte in test file.
 ;
 ; Compress with:
 ;    zx02 -1 input.bin output.zx1
@@ -58,7 +58,7 @@ cop0          lda   (ZX0_src), y
 ;    Elias(length)
               jsr   get_elias
 dzx0s_copy
-              lda   ZX0_dst
+              tya
               sbc   offset  ; C=0 from get_elias
               sta   pntr
               lda   ZX0_dst+1
@@ -66,14 +66,14 @@ dzx0s_copy
               sta   pntr+1
 
 cop1
+              ldy   ZX0_dst
               lda   (pntr), y
-              inc   pntr
-              bne   @+
-              inc   pntr+1
+              ldy   #0
 @             sta   (ZX0_dst),y
               inc   ZX0_dst
               bne   @+
               inc   ZX0_dst+1
+              inc   pntr+1
 @             dex
               bne   cop1
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ how the offsets are stored:
 There are three 6502 assembly decoders, all with ROM-able code and using 8
 bytes of zero-page:
 
-* Fast and small decoder, 138 bytes: [zx02-optim.asm](6502/zx02-optim.asm)
+* Fast and small decoder, 137 bytes: [zx02-optim.asm](6502/zx02-optim.asm)
   **This is the recommended decompressor for most users**
 * Smallest decoder, 121 bytes: [zx02-small.asm](6502/zx02-small.asm)
 * Faster decoder, 175 bytes: [zx02-fast.asm](6502/zx02-fast.asm)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ how the offsets are stored:
 There are three 6502 assembly decoders, all with ROM-able code and using 8
 bytes of zero-page:
 
-* Fast and small decoder, 137 bytes: [zx02-optim.asm](6502/zx02-optim.asm)
+* Fast and small decoder, 134 bytes: [zx02-optim.asm](6502/zx02-optim.asm)
   **This is the recommended decompressor for most users**
 * Smallest decoder, 121 bytes: [zx02-small.asm](6502/zx02-small.asm)
 * Faster decoder, 175 bytes: [zx02-fast.asm](6502/zx02-fast.asm)


### PR DESCRIPTION
I started playing with ZX0 today and found your project. Nice 6502 code!
I made a small optimization. I don't know how to determine cycles/byte - please update yourself or let me know.

I think this could lead to some further optimizations, as `pntr` is now basically just a bitwise negation of `offset`.